### PR TITLE
FIX #112

### DIFF
--- a/ofahrtbase/admin.py
+++ b/ofahrtbase/admin.py
@@ -8,7 +8,7 @@ from .models import Ofahrt, Building, Location, Room
 class OfahrtAdmin(admin.ModelAdmin):
     list_display = ["__str__", "begin_date", "end_date"]
     fieldsets = (("Allgemeines", {
-        "fields": ("begin_date", "end_date")
+        "fields": ("begin_date", "end_date", "active")
     }), ("Einstellungen", {
         "fields": ("member_reg_open", "orga_reg_open", "workshop_reg_open",
                    "max_members", "queue_tolerance", "self_participation")

--- a/ofahrtbase/models.py
+++ b/ofahrtbase/models.py
@@ -45,7 +45,12 @@ class Ofahrt(models.Model):
         help_text="Eingenanteil der Teilnehmer*innen in Cent",
         default=2000)
 
-    active = models.BooleanField("Aktiv?", default=True, unique=True)
+    active = models.BooleanField("Aktiv?", default=False)
+
+    def save(self, *args, **kwargs):
+        if self.active:
+            Ofahrt.objects.all().update(**{'active': False})
+        super(Ofahrt, self).save(*args, **kwargs)
 
     def __str__(self):
         return "Ofahrt im Wintersemester " + str(self.begin_date.year)


### PR DESCRIPTION
With this fix you will be able to add new ofahrt objects. Furthermore, the ability was added to edit the "active" status of an existing ofahrt object. If another active ofahrt object already exists, its status will be set to inactive automatically, when a new active ofahrt object will be saved (so multiple active ofahrt objects are not possible).
But a new issue is revealed, see #114.