### PR TITLE
Essenszeiten angepasst (2018)

### DIFF
--- a/ofahrtbase/templates/ofahrtbase/nametags.tex
+++ b/ofahrtbase/templates/ofahrtbase/nametags.tex
@@ -109,12 +109,12 @@
 		\begin{tabular}{r|l}
 		Wann? & Was?\\
 		\hline
-		Fr. 	17:30 & Anfangsplenum\\
-		Fr./Sa.	19:00 & Abendessen\\
-		Fr./Sa. 20:30 & Abendprogramm\\
-		Sa./So. 08:30 & Frühstück\\
-		Sa.     12:30 & Mittagessen\\
-		So. 	11:30 & Abschl. \& Essen\\
+		Fr. 	16:30 & Anfangsplenum\\
+		Fr./Sa.	18:00 & Abendessen\\
+		Sa./So. 08:15 & Frühstück\\
+		Sa./So. 12:00 & Mittagessen\\
+		Fr. 	20:00 & Lagerfeuer\\
+		Sa. 	21:30 & Party\\
 		\end{tabular}
     \end{textblock*}
 

--- a/workshops/templates/workshops/ofahrtheft.tex
+++ b/workshops/templates/workshops/ofahrtheft.tex
@@ -45,13 +45,9 @@ Einen detaillierten Ablaufplan findest du auf der Rückseite dieses Hefts. Wir u
 \addsec{Essen}
 Feste Essenszeiten gemeinsam im großen Speisesaal:
 \begin{itemize}
-\item Frühstück: 08:30 bis 09:30
-\item Mittagessen:
-\begin{itemize}
-    \item Samstag: 12:30 bis 13:30
-    \item Sonntag: 12:00 bis 13:00
-\end{itemize}
-\item Abendessen: 19:00 bis 20:00
+\item Frühstück: 08:15 bis 09:15
+\item Mittagessen: 12:00 bis 13:00
+\item Abendessen: 18:00 bis 19:00
 \end{itemize}
 
 


### PR DESCRIPTION
Temporärer Fix für Essenszeiten für #130. Oinforz-Rückseite (Gesamtstundenplan ist noch nicht angepasst, da das Programm noch nicht fertig ist und die Zeit für das Lagerfeuer ist noch nicht klar auf den Namensschildern.